### PR TITLE
switch server URLs

### DIFF
--- a/crawlingathome.py
+++ b/crawlingathome.py
@@ -687,7 +687,7 @@ if __name__ == "__main__":
     import numpy as np
 
     YOUR_NICKNAME_FOR_THE_LEADERBOARD = "Kris"
-    CRAWLINGATHOME_SERVER_URL = "http://crawlingathome.duckdns.org/"
+    CRAWLINGATHOME_SERVER_URL = "https://api.gagepiracy.com:4483/"
     import logging
     logging.basicConfig(filename="log.log", level=logging.INFO)
     client = cah.init(


### PR DESCRIPTION
I also mentioned this on Wikidepia's repo, but thought I might as well submit a PR on the forks too.

As the servers just switched, we are trying to move away from DuckDNS's DDNS service because of the fact it may have stability issues as it is a free service. @DefinatelyNotSam on discord has connected us up with a much more powerful server on their hardware, as well as a much more reliable DNS.